### PR TITLE
Set empty attributes to prevent exception in callbacks

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -180,6 +180,8 @@ class LHC(callbacks.Plugin):
                         sep = ircutils.bold(sep)
                     headlines = self.buildHeadlines(newheadlines, channel)
                     self.log.info('Sending message to %s', channel)
+                    setattr(irc, "to", None)
+                    setattr(irc, "private", None)
                     irc.replies(headlines, prefixer='', joiner=sep,
                                 to=channel, prefixNick=False, private=True)
         finally:


### PR DESCRIPTION
This is very definitely a bodge,  to prevent errors of the following form and allow replies to be sent to channels.

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/home/tom/virtenvs/portal-bot/plugins/LHC/plugin.py", line 185, in _newHeadlines
    to=channel, prefixNick=False, private=True)
  File "/home/tom/.virtualenvs/portal-bot/local/lib/python2.7/site-packages/supybot/callbacks.py", line 479, in replies
    to = self._getTarget(kwargs.get('to'))
  File "/home/tom/.virtualenvs/portal-bot/local/lib/python2.7/site-packages/supybot/callbacks.py", line 465, in _getTarget
    target = self.private and self.to or self.msg.args[0]
  File "/home/tom/.virtualenvs/portal-bot/local/lib/python2.7/site-packages/supybot/callbacks.py", line 623, in __getattr__
    return getattr(self.irc, attr)
AttributeError: 'Irc' object has no attribute 'private'
```